### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 donate-wagtail-locust
 ---------------------
 
-This project aims to help us in capacity planning for the new wagtail based donate platform we're launching in late 2019.
+This project aims to help us in capacity planning for the new wagtail based donation platform we're launching in late 2019.
 
 ### Running with Docker locally
 


### PR DESCRIPTION
This is a platform for making donations. 'Donation' is a noun, and when stuck in front of the word 'platform' it is a noun adjunct, which is a noun acting like an adjective. It makes less sense to use a verb in this role. People don't use this platform to make donates. Imagine if you'd built an 'assess platform', a 'meet tool' or purchased an 'inspect lamp'; in these cases the corresponding nouns assessment, meeting and inspection work better.

Of course, language is fluid, and house styles exist, and 'donate platform' may well be what the team calls it, and be much less of a bugbear to you than it is to me 🦕. 🤷